### PR TITLE
Fix V730 warning from PVS-Studio Static Analyzer

### DIFF
--- a/Rand.hpp
+++ b/Rand.hpp
@@ -14,15 +14,14 @@ private:
   unsigned long y;
   unsigned long z;
   unsigned long w;
-  unsigned long t; //tmp
 };
 
 inline unsigned long Rand::next(){
-    this->t=(this->x^(this->x<<11));
+    unsigned long t=(this->x^(this->x<<11));
     this->x=this->y;
     this->y=this->z;
     this->z=this->w;
-    return (this->w=(this->w^(this->w>>19))^(this->t^(this->t>>8)));
+    return (this->w=(this->w^(this->w>>19))^(t^(t>>8)));
 }
 
 inline double Rand::zero2one(){


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Not all members of a class are initialized inside the constructor.
Consider inspecting: t.